### PR TITLE
Fix unarchive ansible step

### DIFF
--- a/.ansible/roles/db/tasks/postgres_sqlite_fdw.yml
+++ b/.ansible/roles/db/tasks/postgres_sqlite_fdw.yml
@@ -17,6 +17,7 @@
 
 - name: Untar SQLite FDW package
   ansible.builtin.unarchive:
+    remote_src: true
     src: "{{ sqlite_fdw_tar_location }}"
     dest: "{{ sqlite_fdw_untar_location }}"
 


### PR DESCRIPTION
Ansible unarchive step needed `remote_src: true` because tar is already on target host.