### PR TITLE
Remove CSS Map reference to get collectstatic to work

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -12183,5 +12183,3 @@ h3.sub-show-name {
     text-align: left;
   }
 }
-
-/*# sourceMappingURL=main.css.map */


### PR DESCRIPTION
Even though the css.map line was commented out, the Django collectstatic process still tried to rewrite it. Since the map file was correctly moved out of /static/ that caused collectstatic to fail. This commit removes the line entirely so that collectstatic succeeds.