### PR TITLE
Fix venv creation issue

### DIFF
--- a/.ansible/roles/web/tasks/static.yml
+++ b/.ansible/roles/web/tasks/static.yml
@@ -10,7 +10,7 @@
 
 - name: Collect static files
   ansible.builtin.command:
-    cmd: "{{ virtualenv_python_bin }} {{ project_source_dir }}/manage.py collectstatic --noinput"
+    cmd: "PYTHONDONTWRITEBYTECODE=1 {{ virtualenv_python_bin }} {{ project_source_dir }}/manage.py collectstatic --noinput"
   environment: "{{ env_vars }}"
   become: yes
 


### PR DESCRIPTION
venv creation was failing because collectstatic is run by root it put undeletable pyc files into the .venv
This makes it so collectstatic doesn’t make pyc files